### PR TITLE
Support python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_sdk",
-    version="0.0.11",
+    version="0.0.12",
     author="MonaLabs",
     author_email="sdk@monalabs.io",
     description="SDK for communicating with Mona's servers",
@@ -17,6 +17,7 @@ setuptools.setup(
         "pyjwt==1.7.1",
         "python-jose>=3.2.0",
         "requests-mock>=1.8.0",
+        "dataclasses==0.8",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Add dataclasses to requirements to support python 3.6