### PR TITLE
Update the author arg description in upload_config()

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ download a suggested configuration which might include new fields based on the d
 Arguments:
     
 - **config**: Your new Mona [configuration](https://docs.monalabs.io/docs/configuration-overview) represented as a 
-  python dict (both the configuration dict with your user_id as the top key and just the configuration dict are 
+  python dict (both the configuration dict with your user_id as the top key and just the configuration dict itself are 
   accepted).
 - **commit_message**: A short description of the changes that were made.
 - **author**: An email address identifying the configuration uploader. Mona will use this mail to send updates regarding
-  re-creation of insights upon this configuration change. When not supplied, the author will be the Client's api-key and 
-  you will not get updates regarding the changes mentioned above. Must be provided when using un-authenticated mode.
+  re-creation of insights upon this configuration change. When not supplied, the author will be the Client's api-key, 
+  and you will not get updates regarding the changes mentioned above. Must be provided when using un-authenticated mode.
 ```
 new_configuration = {
     "MY_CONTEXT_CLASS": {

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ download a suggested configuration which might include new fields based on the d
 Arguments:
     
 - **config**: Your new Mona [configuration](https://docs.monalabs.io/docs/configuration-overview) represented as a 
-  python dict (no need to add your user_id as the key, just the configuration itself).
+  python dict (both the configuration dict with your user_id as the top key and just the configuration dict are 
+  accepted).
 - **commit_message**: A short description of the changes that were made.
 - **author**: An email address identifying the configuration uploader. Mona will use this mail to send updates regarding
   re-creation of insights upon this configuration change. When not supplied, the author will be the Client's api-key and 

--- a/README.md
+++ b/README.md
@@ -76,27 +76,43 @@ export_result = my_mona_client.export_batch(messages_batch_to_mona)
 Mona's sdk provides simple ways to upload a new Mona configuration, download your current mona configuration, or 
 download a suggested configuration which might include new fields based on the data you previously exported to Mona.
 
-- Upload a new configuration:
-    ```
-    # Note: no need to add your user_id as the key, just the configuration itself.
-    new_configuration = <Your new Mona configuration represented as a python dict>
-    author = 'author@mycompany.io'  # A string identifying the user who sent the configuration (only required if you are using unauthenticated mode).
-    upload_result = my_client.upload_config(new_configuration, "My commit message", author)
+#### Upload a new configuration:
+
+Arguments:
     
-    # the return value format will be:
-    # upload_result == {
-    #    "success": <was the upload successful>, (bool)
-    #    "new_config_id": <the new configuration ID> (str)
-    #}
-    ```
-- Get your current Mona configuration:
-    ```
-    my_current_mona_config = my_client.get_config()
-    ```
-- Get a suggested configuration based on your data:
-    ```
-    my_suggested_mona_config = my_client.get_suggested_config()
-    ```
+- **config**: Your new Mona [configuration](https://docs.monalabs.io/docs/configuration-overview) represented as a 
+  python dict (no need to add your user_id as the key, just the configuration itself).
+- **commit_message**: A short description of the changes that were made.
+- **author**: An email address identifying the configuration uploader. Mona will use this mail to send updates regarding
+  re-creation of insights upon this configuration change. When not supplied, the author will be the Client's api-key and 
+  you will not get updates regarding the changes mentioned above. Must be provided when using un-authenticated mode.
+```
+new_configuration = {
+    "MY_CONTEXT_CLASS": {
+        "fields": <fields dict>, 
+        "field_vectors": <field vectors dict>
+        "stanzas_global_defaults": <global defaults dict>, 
+        "stanzas": <stansas dict>,
+        "notifications": <notifications dict>
+    }
+}
+author = 'author@mycompany.io'
+upload_result = my_client.upload_config(new_configuration, "My commit message", author)
+
+# the return value format will be:
+# upload_result == {
+#    "success": <was the upload successful>, (bool)
+#    "new_config_id": <the new configuration ID> (str)
+#}
+```
+#### Get your current Mona configuration:
+```
+my_current_mona_config = my_client.get_config()
+```
+####Get a suggested configuration based on your data:
+```
+my_suggested_mona_config = my_client.get_suggested_config()
+```
 
 ## Environment variables
 

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -386,7 +386,11 @@ class Client:
         :param config: (dict) your configuration, no need for your tenant id as key,
         first layer of keys should be the context classes.
         :param commit_message: (str)
-        :param author: (str) provide this field if you are using unauthenticated mode.
+        :param author: (str) An email address identifying the configuration uploader.
+        Mona will use this mail to send updates regarding re-creation of insights upon
+        this configuration change. When not supplied, the author will be the Client's
+        api-key and you will not get updates regarding the changes mentioned above.
+        Must be provided when using un-authenticated mode.
         :return: A dict holding the upload data:
         {
             "success": <was the upload successful>, (bool)

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -397,17 +397,29 @@ class Client:
             "new_config_id": <the new configuration ID> (str)
         }
         """
+        upload_output = {"success": False, "new_config_id": ""}
+
         if not author and not self.should_use_authentication:
             self._handle_config_error(
-                "when using non authenticated client, author must be provided"
+                "When using non authenticated client, author must be provided."
             )
+            return upload_output
+
+        if not isinstance(config, dict):
+            self._handle_config_error("config must be a dict.")
+            return upload_output
+
+        keys_list = list(config.keys())
+        if len(keys_list) == 1 and keys_list[0] == self._user_id:
+            config = config[keys_list[0]]
+
         config_to_upload = {
             "config": {self._user_id: config},
             "author": author or self.api_key,
             "commit_message": commit_message,
             "user_id": self._user_id,
         }
-        upload_output = {"success": False, "new_config_id": ""}
+
         try:
             upload_response = requests.post(
                 f"{self._app_server_url}/upload_config",

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -383,8 +383,9 @@ class Client:
         preferences.
         Find more information on creating your configuration at:
         https://docs.monalabs.io/.
-        :param config: (dict) your configuration, no need for your tenant id as key,
-        first layer of keys should be the context classes.
+        :param config: (dict) Your new Mona configuration represented as a python dict
+        (both the configuration dict with your user_id as the top key and just the
+        configuration dict itself are accepted)
         :param commit_message: (str)
         :param author: (str) An email address identifying the configuration uploader.
         Mona will use this mail to send updates regarding re-creation of insights upon

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_sdk",
-    version="0.0.20",
+    version="0.0.21",
     author="MonaLabs",
     author_email="sdk@monalabs.io",
     description="SDK for communicating with Mona's servers",


### PR DESCRIPTION
Updated the README + upload_config() doc with the use of the "author" arg. I decided to leave the "author" arg optional when using authenticated mode (in case they don't care about getting mails and then the author is the api-key), lmk if you disagree.

Also did some changes in the config example.

