### PR TITLE
Added dot validation and allow_sub_context_class arg/ENV VAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,12 @@ Mona uses several environment variables you can set as you prefer:
 - MONA_SDK_SHOULD_LOG_FAILED_MESSAGES - When true, failed messages will be logged ("ERROR" level).
 - MONA_SDK_OVERRIDE_REST_API_URL- When provided, all messages to mona's rest-api will use this address instead of the default 
   one.
-- MONA_SDK_OVERRIDE_APP_SERVER_URL When provided, all configuration related calls to mona's servers will use this address instead
+- MONA_SDK_OVERRIDE_APP_SERVER_URL - When provided, all configuration related calls to mona's servers will use this address instead
   of the default one.
+- MONA_SDK_ALLOW_SUB_CONTEXT_CLASS - When set to True, allow the dot ('.') char in context_classes and context_ids, This 
+  char is used as a sub-class separator on Mona's servers, so set this argument to True only if you want to use Mona's 
+  sub-classes logic (default: False).
+  
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
 constructor as follows (the environment variables are used as defaults for these arguments):

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -86,6 +86,11 @@ SHOULD_LOG_FAILED_MESSAGES = get_boolean_value_for_env_var(
     "MONA_SDK_SHOULD_LOG_FAILED_MESSAGES", False
 )
 
+# When this variable is True, allow the '.' char in context_classes and context_ids.
+ALLOW_SUB_CONTEXT_CLASS = get_boolean_value_for_env_var(
+    "MONA_SDK_ALLOW_SUB_CONTEXT_CLASS", False
+)
+
 GET_CONFIG_ERROR_MESSAGE = "Could not get server response with the current config."
 UPLOAD_CONFIG_ERROR_MESSAGE = (
     "Could not upload the new configuration, please check it is valid."
@@ -161,6 +166,7 @@ class Client:
         should_use_authentication=SHOULD_USE_AUTHENTICATION,
         override_rest_api_url=OVERRIDE_REST_API_URL,
         override_app_server_url=OVERRIDE_APP_SERVER_URL,
+        allow_sub_context_class=ALLOW_SUB_CONTEXT_CLASS,
         user_id=None,
     ):
         """
@@ -185,6 +191,7 @@ class Client:
         self.should_log_failed_messages = should_log_failed_messages
         self.should_use_ssl = should_use_ssl
         self.should_use_authentication = should_use_authentication
+        self.allow_sub_context_class = allow_sub_context_class
 
         if should_use_authentication:
             self.raise_authentication_exceptions = raise_authentication_exceptions
@@ -278,7 +285,9 @@ class Client:
 
         messages_to_send = []
         for message_event in events:
-            if not validate_mona_single_message(message_event):
+            if not validate_mona_single_message(
+                message_event, self.allow_sub_context_class
+            ):
                 return handle_export_error(
                     "Messages to export must be of MonaSingleMessage type.",
                     self.raise_export_exceptions,


### PR DESCRIPTION
Added a new ENV VAR / constructor argument: ALLOW_SUB_CONTEXT_CLASS.
When False (default), the Client will not allow '.' in the contexts class and context id (and will log an error/raise exception according to RAISE_EXPORT_EXCEPTIONS).

Monday: https://mona-product-and-eng.monday.com/boards/543114669/pulses/798575709
