### PR TITLE
Add override_rest_api_host/app_server_host env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,22 @@ Mona uses several environment variables you can set as you prefer:
 - MONA_SDK_WAIT_TIME_FOR_AUTHENTICATION_RETRIES_SEC - Number of seconds to wait between 
   every authentication retry (default value: 2).
 - MONA_SDK_SHOULD_LOG_FAILED_MESSAGES - When true, failed messages will be logged ("ERROR" level).
-- MONA_SDK_OVERRIDE_REST_API_URL- When provided, all messages to mona's rest-api will use this address instead of the default 
-  one.
-- MONA_SDK_OVERRIDE_APP_SERVER_URL When provided, all configuration related calls to mona's servers will use this address instead
-  of the default one.
+- MONA_SDK_OVERRIDE_APP_SERVER_HOST - When provided, all configuration related calls to mona's servers will use this 
+  host name instead of the default one ("api<user_id>.monalabs.io").
+- MONA_SDK_OVERRIDE_REST_API_HOST- When provided, all messages (data export) to mona's rest-api will use this host 
+  address instead of the default one ("incoming<user_id>.monalabs.io").
+- MONA_SDK_OVERRIDE_REST_API_URL- When provided, all messages to mona's rest-api will use this full url address 
+  (including "http" prefix and endpoints suffix) instead of the default one. 
+  **Note**: this is mostly for internal use, please use MONA_SDK_OVERRIDE_REST_API_HOST if needed.
+- MONA_SDK_SHOULD_USE_SSL - Should the communication with Mona's servers be with (https) or without (http) ssl 
+  (default: True).
+- MONA_SDK_SHOULD_USE_AUTHENTICATION - When set to false, the communication with Mona's servers will not use 
+  authentication (user_id should be provided to the Client constructor instead of an api_key and a secret), **Note**: 
+  this mode is not automatically supported and must be explicitly requested from Mona's team.
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
-constructor as follows (the environment variables are used as defaults for these arguments):
+constructor as follows (the environment variables are used as defaults for these arguments, and by passing these 
+arguments to the constructor you can override the default values you set with the environment variables):
 ```
 my_mona_client = Client(
     api_key,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Mona uses several environment variables you can set as you prefer:
   (default: True).
 - MONA_SDK_SHOULD_USE_AUTHENTICATION - When set to false, the communication with Mona's servers will not use 
   authentication (user_id should be provided to the Client constructor instead of an api_key and a secret), **Note**: 
-  this mode is not automatically supported and must be explicitly requested from Mona's team.
+  this mode is not supported on the servers by default, and must be explicitly requested from Mona's team.
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
 constructor as follows (the environment variables are used as defaults for these arguments, and by passing these 

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -66,6 +66,8 @@ SHOULD_USE_SSL = get_boolean_value_for_env_var("MONA_SDK_SHOULD_USE_SSL", True)
 
 OVERRIDE_APP_SERVER_HOST = os.environ.get("MONA_SDK_OVERRIDE_APP_SERVER_HOST")
 
+# TODO(anat): Once no one is using it, remove this env var (leave only
+#  OVERRIDE_REST_API_HOST).
 OVERRIDE_REST_API_URL = os.environ.get("MONA_SDK_OVERRIDE_REST_API_URL")
 OVERRIDE_REST_API_HOST = os.environ.get("MONA_SDK_OVERRIDE_REST_API_HOST")
 
@@ -205,14 +207,15 @@ class Client:
         # this point the client was successfully authenticated and self._get_user_id()
         # will work.
         self._user_id = user_id or self._get_user_id()
-        self._rest_api_url = override_rest_api_full_url or self._get_rest_api_url(
-            override_host=override_rest_api_host
+        self._rest_api_url = (
+            override_rest_api_full_url
+            or self._get_rest_api_export_url(override_host=override_rest_api_host)
         )
         self._app_server_url = self._get_app_server_url(
             override_host=override_app_server_host
         )
 
-    def _get_rest_api_url(self, override_host=None):
+    def _get_rest_api_export_url(self, override_host=None):
         http_protocol = "https" if self.should_use_ssl else "http"
         host_name = override_host or f"incoming{self._user_id}.monalabs.io"
         endpoint_name = "export" if self.should_use_authentication else "monaExport"

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -64,9 +64,10 @@ SHOULD_USE_AUTHENTICATION = get_boolean_value_for_env_var(
 
 SHOULD_USE_SSL = get_boolean_value_for_env_var("MONA_SDK_SHOULD_USE_SSL", True)
 
-OVERRIDE_APP_SERVER_URL = os.environ.get("MONA_SDK_OVERRIDE_APP_SERVER_URL")
+OVERRIDE_APP_SERVER_HOST = os.environ.get("MONA_SDK_OVERRIDE_APP_SERVER_HOST")
 
 OVERRIDE_REST_API_URL = os.environ.get("MONA_SDK_OVERRIDE_REST_API_URL")
+OVERRIDE_REST_API_HOST = os.environ.get("MONA_SDK_OVERRIDE_REST_API_HOST")
 
 # Number of retries to authenticate in case the authentication server failed to
 # respond.
@@ -159,8 +160,9 @@ class Client:
         should_log_failed_messages=SHOULD_LOG_FAILED_MESSAGES,
         should_use_ssl=SHOULD_USE_SSL,
         should_use_authentication=SHOULD_USE_AUTHENTICATION,
-        override_rest_api_url=OVERRIDE_REST_API_URL,
-        override_app_server_url=OVERRIDE_APP_SERVER_URL,
+        override_rest_api_full_url=OVERRIDE_REST_API_URL,
+        override_rest_api_host=OVERRIDE_REST_API_HOST,
+        override_app_server_host=OVERRIDE_APP_SERVER_HOST,
         user_id=None,
     ):
         """
@@ -203,17 +205,23 @@ class Client:
         # this point the client was successfully authenticated and self._get_user_id()
         # will work.
         self._user_id = user_id or self._get_user_id()
-        self._rest_api_url = override_rest_api_url or self._get_rest_api_url()
-        self._app_server_url = override_app_server_url or self._get_app_server_url()
+        self._rest_api_url = override_rest_api_full_url or self._get_rest_api_url(
+            override_host=override_rest_api_host
+        )
+        self._app_server_url = self._get_app_server_url(
+            override_host=override_app_server_host
+        )
 
-    def _get_rest_api_url(self):
+    def _get_rest_api_url(self, override_host=None):
         http_protocol = "https" if self.should_use_ssl else "http"
+        host_name = override_host or f"incoming{self._user_id}.monalabs.io"
         endpoint_name = "export" if self.should_use_authentication else "monaExport"
-        return f"{http_protocol}://incoming{self._user_id}.monalabs.io/{endpoint_name}"
+        return f"{http_protocol}://{host_name}/{endpoint_name}"
 
-    def _get_app_server_url(self):
+    def _get_app_server_url(self, override_host=None):
         http_protocol = "https" if self.should_use_ssl else "http"
-        return f"{http_protocol}://api{self._user_id}.monalabs.io"
+        host_name = override_host or f"api{self._user_id}.monalabs.io"
+        return f"{http_protocol}://{host_name}"
 
     def is_active(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_sdk",
-    version="0.0.21",
+    version="0.0.22",
     author="MonaLabs",
     author_email="sdk@monalabs.io",
     description="SDK for communicating with Mona's servers",


### PR DESCRIPTION
rest-api address env vars:
OVERRIDE_REST_API_URL - already exists. This is not the correct way to change rest api address (this overrides the entire url including the endpoint and the 'http/s' prefix) but MoD are already using it so i'm not removing it.
MONA_SDK_OVERRIDE_REST_API_HOST - a new env var. overrides only the host part of the address ('incoming-<user_id>').

app-server address:
MONA_SDK_OVERRIDE_APP_SERVER_URL -> MONA_SDK_OVERRIDE_APP_SERVER_HOST: changed the name and the behavior to override only the  host part of the address. 

In addition, added some info to the README about MONA_SDK_SHOULD_USE_SSL and MONA_SDK_SHOULD_USE_AUTHENTICATION that I noticed I didn't add before. @itaiMona can you please take a look at the README? thanks.