### PR TITLE
Add all services functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,22 @@ for context_instance in my_data:
         
 export_result = my_mona_client.export_batch(messages_batch_to_mona)
 ```
-### Configuration handling
-Mona's sdk provides simple ways to upload a new Mona configuration, download your current mona configuration, or 
-download a suggested configuration which might include new fields based on the data you previously exported to Mona.
+## Mona SDK services
+Mona sdk provides a simple API to your information on Mona. You can see all functions info and examples on 
+[our docs](https://docs.monalabs.io/docs) under REST API.
+
+### The available services are:
+
+#### [get_suggested_config](https://docs.monalabs.io/docs/retrieve-suggested-config-via-rest-api)
+#### [validate_config](https://docs.monalabs.io/docs/validate-config-via-rest-api)
+#### [upload_config_per_context_class](https://docs.monalabs.io/docs/upload-config-per-context-class-via-rest-api)
+#### [get_config_history](https://docs.monalabs.io/docs/retrieve-config-history-via-rest-api)
+#### [get_insights](https://docs.monalabs.io/docs/retrieve-insights-using-the-rest-api)
+#### [get_ingested_data_for_a_specific_segment](https://docs.monalabs.io/docs/retrieve-ingested-data-for-a-specific-segment-via-rest-api)
+#### [get_suggested_config_from_user_input](https://docs.monalabs.io/docs/retrieve-suggested-config-from-user-input-via-rest-api)
+#### [get_aggregated_data_of_a_specific_segment](https://docs.monalabs.io/docs/retrieve-aggregated-data-of-a-specific-segment-via-rest-api)
+#### [get_aggregated_stats_of_a_specific_segmentation](https://docs.monalabs.io/docs/retrieve-stats-of-specific-segmentation-via-rest-api)
+
 
 #### Upload a new configuration:
 
@@ -106,14 +119,7 @@ upload_result = my_client.upload_config(new_configuration, "My commit message", 
 #    "new_config_id": <the new configuration ID> (str)
 #}
 ```
-#### Get your current Mona configuration:
-```
-my_current_mona_config = my_client.get_config()
-```
-#### Get a suggested configuration based on your data:
-```
-my_suggested_mona_config = my_client.get_suggested_config()
-```
+
 
 ## Environment variables
 
@@ -125,8 +131,9 @@ Mona uses several environment variables you can set as you prefer:
 - MONA_SDK_RAISE_EXPORT_EXCEPTIONS - set to true if you would like Mona's client to
   raise export related exceptions. When set to false and an export (or part of it) fails,
   the failure reason will be logged (default value: False).
-- MONA_SDK_RAISE_CONFIG_EXCEPTIONS - set to true if you would like Mona's client to
-  raise config related exceptions. When set to false, and such an exception is met,
+- MONA_SDK_RAISE_SERVICE_EXCEPTIONS - set to true if you would like Mona's client to
+  raise services requests related exceptions (see all available services under [Mona SDK services](#mona-sdk-services) 
+  section in this doc). When set to false, and such an exception is met,
   the function will log an error and return false (default value: False).
 - MONA_SDK_NUM_OF_RETRIES_FOR_AUTHENTICATION - Number of retries to authenticate in case 
   Mona's client unexpectedly cannot get an authentication response from the server
@@ -156,7 +163,7 @@ my_mona_client = Client(
     secret,
     raise_authentication_exceptions=True,
     raise_export_exceptions=True,
-    raise_config_exceptions=True,
+    raise_service_exceptions=True,
     num_of_retries_for_authentication=6,
     wait_time_for_authentication_retries=0,
     should_log_failed_messages=True,

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ for context_instance in my_data:
 export_result = my_mona_client.export_batch(messages_batch_to_mona)
 ```
 ## Mona SDK services
-Mona sdk provides a simple API to your information on Mona. You can see all functions info and examples on 
-[our docs](https://docs.monalabs.io/docs) under REST API.
+Mona sdk provides a simple API to access your information and control your configuration and data on Mona.
+You can see all functions info and examples on [our docs](https://docs.monalabs.io/docs) under REST API.
 
 ### The available services are:
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ Mona sdk provides a simple API to your information on Mona. You can see all func
 #### [get_aggregated_data_of_a_specific_segment](https://docs.monalabs.io/docs/retrieve-aggregated-data-of-a-specific-segment-via-rest-api)
 #### [get_aggregated_stats_of_a_specific_segmentation](https://docs.monalabs.io/docs/retrieve-stats-of-specific-segmentation-via-rest-api)
 
-
+#### Get your current Mona configuration:
+```
+my_current_mona_config = my_client.get_config()
+```
 #### Upload a new configuration:
 
 Arguments:

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -575,6 +575,7 @@ class Client:
             },
         )
 
+    @Decorators.refresh_token_if_needed
     def get_ingested_data_for_a_specific_segment(
         self,
         context_class,
@@ -599,6 +600,7 @@ class Client:
             },
         )
 
+    @Decorators.refresh_token_if_needed
     def get_suggested_config_from_user_input(self, events):
         """
         A wrapper function for "Retrieve Suggested Config from User Input" REST
@@ -614,6 +616,7 @@ class Client:
 
         return app_server_response
 
+    @Decorators.refresh_token_if_needed
     def get_aggregated_data_of_a_specific_segment(
         self,
         context_class,
@@ -648,6 +651,7 @@ class Client:
             },
         )
 
+    @Decorators.refresh_token_if_needed
     def get_aggregated_stats_of_a_specific_segmentation(
         self,
         context_class,

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -55,7 +55,7 @@ RAISE_EXPORT_EXCEPTIONS = get_boolean_value_for_env_var(
 )
 
 RAISE_SERVICE_EXCEPTIONS = get_boolean_value_for_env_var(
-    "MONA_SDK_RAISE_CONFIG_EXCEPTIONS", False
+    "MONA_SDK_RAISE_SERVICE_EXCEPTIONS", False
 )
 
 SHOULD_USE_AUTHENTICATION = get_boolean_value_for_env_var(
@@ -89,7 +89,7 @@ SHOULD_LOG_FAILED_MESSAGES = get_boolean_value_for_env_var(
     "MONA_SDK_SHOULD_LOG_FAILED_MESSAGES", False
 )
 
-SERVICE_ERROR_MESSAGE = "Could not get server response with the wanted service."
+SERVICE_ERROR_MESSAGE = "Could not get server response for the wanted service."
 UPLOAD_CONFIG_ERROR_MESSAGE = (
     "Could not upload the new configuration, please check it is valid."
 )
@@ -103,7 +103,7 @@ UNAUTHENTICATED_ERROR_CHECK_MESSAGE = (
 # The argument to use as a default value on the values of the data argument (dict) when
 # calling _app_server_request(). Use this and not None in order to be able to pass a
 # None argument if needed.
-UNPROVIDED_FIELD = "unprovided field"
+UNPROVIDED_VALUE = "mona_unprovided_value"
 
 
 @dataclass
@@ -509,10 +509,14 @@ class Client:
         documentation here:
         https://docs.monalabs.io/docs/retrieve-suggested-config-via-rest-api
         """
-        return self._app_server_request("get_new_config_fields")
+        app_server_response = self._app_server_request("get_new_config_fields")
+        try:
+            return app_server_response["response_data"]["suggested_config"]
+        except KeyError:
+            return self._handle_service_error(SERVICE_ERROR_MESSAGE)
 
     @Decorators.refresh_token_if_needed
-    def get_config_history(self, number_of_revisions=UNPROVIDED_FIELD):
+    def get_config_history(self, number_of_revisions=UNPROVIDED_VALUE):
         """
         A wrapper function for "Retrieve Config History" REST endpoint. view full
         documentation here:
@@ -526,8 +530,8 @@ class Client:
     def validate_config(
         self,
         config,
-        list_of_context_ids=UNPROVIDED_FIELD,
-        latest_amount=UNPROVIDED_FIELD,
+        list_of_context_ids=UNPROVIDED_VALUE,
+        latest_amount=UNPROVIDED_VALUE,
     ):
         """
         A wrapper function for "Validate Config" REST endpoint. view full documentation
@@ -547,11 +551,11 @@ class Client:
         self,
         context_class,
         min_segment_size,
-        insight_types=UNPROVIDED_FIELD,
-        metric_name=UNPROVIDED_FIELD,
-        min_insight_score=UNPROVIDED_FIELD,
-        time_range_seconds=UNPROVIDED_FIELD,
-        first_discovered_on_range_seconds=UNPROVIDED_FIELD,
+        insight_types=UNPROVIDED_VALUE,
+        metric_name=UNPROVIDED_VALUE,
+        min_insight_score=UNPROVIDED_VALUE,
+        time_range_seconds=UNPROVIDED_VALUE,
+        first_discovered_on_range_seconds=UNPROVIDED_VALUE,
     ):
         """
         A wrapper function for "Retrieve Insights" REST endpoint. view full
@@ -577,7 +581,7 @@ class Client:
         start_time,
         end_time,
         segment,
-        excluded_segments=UNPROVIDED_FIELD,
+        excluded_segments=UNPROVIDED_VALUE,
     ):
         """
         A wrapper function for "Retrieve Ingested Data for a Specific Segment" REST
@@ -615,13 +619,13 @@ class Client:
         context_class,
         timestamp_from,
         timestamp_to,
-        time_series_resolutions=UNPROVIDED_FIELD,
-        with_histogram=UNPROVIDED_FIELD,
-        time_zone=UNPROVIDED_FIELD,
-        metrics=UNPROVIDED_FIELD,
-        requested_segments=UNPROVIDED_FIELD,
-        excluded_segments=UNPROVIDED_FIELD,
-        baseline_segment=UNPROVIDED_FIELD,
+        time_series_resolutions=UNPROVIDED_VALUE,
+        with_histogram=UNPROVIDED_VALUE,
+        time_zone=UNPROVIDED_VALUE,
+        metrics=UNPROVIDED_VALUE,
+        requested_segments=UNPROVIDED_VALUE,
+        excluded_segments=UNPROVIDED_VALUE,
+        baseline_segment=UNPROVIDED_VALUE,
     ):
         """
         A wrapper function for "Retrieve Aggregated Data of a Specific Segment" REST
@@ -656,10 +660,10 @@ class Client:
         metric_2_type,
         min_segment_size,
         sort_function,
-        baseline_segment=UNPROVIDED_FIELD,
-        excluded_segments=UNPROVIDED_FIELD,
-        target_segments_filter=UNPROVIDED_FIELD,
-        compared_segments_filter=UNPROVIDED_FIELD,
+        baseline_segment=UNPROVIDED_VALUE,
+        excluded_segments=UNPROVIDED_VALUE,
+        target_segments_filter=UNPROVIDED_VALUE,
+        compared_segments_filter=UNPROVIDED_VALUE,
     ):
         """
         A wrapper function for "Retrieve Aggregated Stats of Specific Segmentation" REST
@@ -730,7 +734,7 @@ class Client:
                 ),
                 # Remove keys with UNPROVIDED_FIELD values to avoid overriding the
                 # default value on the endpoint itself.
-                json=remove_items_by_value(data, UNPROVIDED_FIELD) if data else {},
+                json=remove_items_by_value(data, UNPROVIDED_VALUE) if data else {},
             )
             json_response = app_server_response.json()
             if not app_server_response.ok:

--- a/mona_sdk/client_exceptions.py
+++ b/mona_sdk/client_exceptions.py
@@ -11,7 +11,7 @@ class MonaAuthenticationException(Exception):
     pass
 
 
-class MonaConfigException(Exception):
+class MonaServiceException(Exception):
     pass
 
 

--- a/mona_sdk/client_util.py
+++ b/mona_sdk/client_util.py
@@ -9,3 +9,11 @@ def get_boolean_value_for_env_var(env_var, default_value):
 
 def is_dict_contains_fields(message_event, required_fields):
     return all((field in message_event for field in required_fields))
+
+
+def remove_items_by_value(data, value_to_remove):
+    """
+    Return a copy of the given dict after removing the items with value_to_remove as
+    value.
+    """
+    return {key: value for key, value in data.items() if value != value_to_remove}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_sdk",
-    version="0.0.22",
+    version="0.0.23",
     author="MonaLabs",
     author_email="sdk@monalabs.io",
     description="SDK for communicating with Mona's servers",


### PR DESCRIPTION
- Added all Rest-api available services wrappers.
- Changed MonaConfigException to MonaServiceException (and all other related code).
- Added links to the documentation for each function on the README file.
- Note: depending on the endpoint on the app-server I changed the way the app-server's response passes to the user, and only checked if I got a good response (200) but a bad outcome (no "response_data" in the response dict for example) when it is possible.

@itaiMona Please take a look at the README and the new functions documentation/names and lmk if you want to change anything (assigning Tal to review the code).

Monday:
https://mona-product-and-eng.monday.com/boards/543114669/pulses/1997688399
https://mona-product-and-eng.monday.com/boards/543114669/pulses/1884777267