### PR TITLE
Filter fields with None values

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ Mona uses several environment variables you can set as you prefer:
   authentication (user_id should be provided to the Client constructor instead of an api_key and a secret), **Note**: 
   this mode is not supported on the servers by default, and must be explicitly requested from Mona's team.
 - MONA_SDK_FILTER_NONE_FIELDS_ON_EXPORT - When set to true, Mona's client will filter out all fields with None values 
-  from the message dict to export. There is an addition argument on both export() and export_batch() called 
-  filter_none_fields that can be used to override this value for a single exported message/batch. (default value: False)
+  from the message dict to export. Note that passing a None value may be required in order to delete a pre-existing 
+  value. To allow None values, use filter_none_fields=False which overrides this parameter both in export() and 
+  export_batch() functions. (default value: False)
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
 constructor as follows (the environment variables are used as defaults for these arguments, and by passing these 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Mona uses several environment variables you can set as you prefer:
 - MONA_SDK_SHOULD_USE_AUTHENTICATION - When set to false, the communication with Mona's servers will not use 
   authentication (user_id should be provided to the Client constructor instead of an api_key and a secret), **Note**: 
   this mode is not supported on the servers by default, and must be explicitly requested from Mona's team.
+- MONA_SDK_FILTER_NONE_FIELDS_ON_EXPORT - When set to true, Mona's client will filter out all fields with None values 
+  from the message dict to export. There is an addition argument on both export() and export_batch() called 
+  filter_none_fields that can be used to override this value for a single exported message/batch. (default value: False)
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
 constructor as follows (the environment variables are used as defaults for these arguments, and by passing these 
@@ -181,6 +184,7 @@ my_mona_client = Client(
     num_of_retries_for_authentication=6,
     wait_time_for_authentication_retries=0,
     should_log_failed_messages=True,
+    filter_none_fields_on_export=True,
 )
 ```
 

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -268,8 +268,12 @@ class Client:
 
     def should_filter_none_fields(self, filter_none_fields):
         """
-        Return True is the None fields should be filtered, if the caller function did
-        not provide filter_none_fields use the client's self default.
+        :param filter_none_fields:
+            The value the export function got for filter_none_fields.
+        :return: boolean
+            True if the None fields should be filtered, if the caller function did
+            not provide filter_none_fields use the client's self default.
+
         """
         return (
             self.filter_none_fields_on_export

--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -22,11 +22,7 @@ import jwt
 import requests
 from requests.exceptions import ConnectionError
 
-from mona_sdk.client_exceptions import (
-    MonaServiceException,
-    MonaInitializationException,
-)
-from .client_util import get_boolean_value_for_env_var, remove_items_by_value
+from mona_sdk.client_exceptions import MonaServiceException, MonaInitializationException
 from .logger import get_logger
 from .validation import (
     handle_export_error,
@@ -35,12 +31,13 @@ from .validation import (
     validate_mona_single_message,
     mona_messages_to_dicts_validation,
 )
+from .client_util import remove_items_by_value, get_boolean_value_for_env_var
 from .authentication import (
     Decorators,
     is_authenticated,
     first_authentication,
-    get_current_token_by_api_key,
     get_basic_auth_header,
+    get_current_token_by_api_key,
 )
 
 # Note: if RAISE_AUTHENTICATION_EXCEPTIONS = False and the client could not
@@ -273,7 +270,6 @@ class Client:
         :return: boolean
             True if the None fields should be filtered, if the caller function did
             not provide filter_none_fields use the client's self default.
-
         """
         return (
             self.filter_none_fields_on_export

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="mona_sdk",
-    version="0.0.24",
+    version="0.0.25",
     author="MonaLabs",
     author_email="sdk@monalabs.io",
     description="SDK for communicating with Mona's servers",


### PR DESCRIPTION
Added an env var + client attribute called FILTER_NONE_FIELDS_ON_EXPORT, this allows users to filter all fields with non values from their messages.
In addition, I also added the argument filter_none_fields to al export functions to allow overriding the instance default for a single export (to allow overriding existing crcs with a None value).

Tested:
Deployed and tested end-to-end locally

[Monday](https://mona-product-and-eng.monday.com/boards/543114669/pulses/2827350532)
