### PR TITLE
Small README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,15 @@ Mona uses several environment variables you can set as you prefer:
   (including "http" prefix and endpoints suffix) instead of the default one. 
   **Note**: this is mostly for internal use, please use MONA_SDK_OVERRIDE_REST_API_HOST if needed.
 - MONA_SDK_SHOULD_USE_SSL - Should the communication with Mona's servers be with (https) or without (http) ssl 
-  (default: True).
+  (default value: True).
 - MONA_SDK_SHOULD_USE_AUTHENTICATION - When set to false, the communication with Mona's servers will not use 
   authentication (user_id should be provided to the Client constructor instead of an api_key and a secret), **Note**: 
-  this mode is not supported on the servers by default, and must be explicitly requested from Mona's team.
+  this mode is not supported on the servers by default, and must be explicitly requested from Mona's team (default 
+  value: True).
 - MONA_SDK_FILTER_NONE_FIELDS_ON_EXPORT - When set to true, Mona's client will filter out all fields with None values 
-  from the message dict to export. Note that passing a None value may be required in order to delete a pre-existing 
+  from the message dict to export (default value: False). Note that passing a None value may be required in order to delete a pre-existing 
   value. To allow None values, use filter_none_fields=False which overrides this parameter both in export() and 
-  export_batch() functions. (default value: False)
+  export_batch() functions.
 
 Another way to control these behaviors is to pass the relevant arguments to the client 
 constructor as follows (the environment variables are used as defaults for these arguments, and by passing these 


### PR DESCRIPTION
Changed the README (env vars part) to be more clear on the MONA_SDK_FILTER_NONE_FIELDS_ON_EXPORT default value.
Please take a look if you see any other missing/unclear parts on the env vars description, thanks:)


[Monday](https://mona-product-and-eng.monday.com/boards/543114669/pulses/2827350532)

Tested: No test, this is only a documentation change