### PR TITLE
Updated get_stats endpoint to get_segments_for_dimensions

### DIFF
--- a/mona_sdk/client.py
+++ b/mona_sdk/client.py
@@ -1031,7 +1031,7 @@ class Client:
         https://docs.monalabs.io/docs/retrieve-stats-of-specific-segmentation-via-rest-api
         """
         app_server_response = self._app_server_request(
-            "stats",
+            "get_segments_for_dimensions",
             data={
                 "context_class": context_class,
                 "dimension": dimension,


### PR DESCRIPTION
Changed get_stats endpoint name to get_segments_for_dimensions (should be backwards compatible with get_stats)